### PR TITLE
virtcontainers: fc: Stop the VM by killing the process

### DIFF
--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -45,6 +46,7 @@ const (
 	//FcTimeout is the maximum amount of time in seconds to wait for the VMM to respond
 	FcTimeout  = 10
 	fireSocket = "firecracker.sock"
+	fcStopSandboxTimeout = 15
 )
 
 func (s vmmState) String() string {
@@ -58,6 +60,10 @@ func (s vmmState) String() string {
 	}
 
 	return ""
+}
+
+type FirecrackerInfo struct {
+	PID int
 }
 
 type firecrackerState struct {
@@ -82,6 +88,7 @@ const fcDiskPoolSize = 8
 type firecracker struct {
 	id    string //Unique ID per pod. Normally maps to the sandbox id
 	state firecrackerState
+	info  FirecrackerInfo
 
 	firecrackerd *exec.Cmd           //Tracks the firecracker process itself
 	client       *client.Firecracker //Tracks the current active connection
@@ -134,6 +141,12 @@ func (fc *firecracker) init(ctx context.Context, id string, hypervisorConfig *Hy
 	fc.storage = storage
 	fc.config = *hypervisorConfig
 	fc.state.set(notReady)
+
+	// No need to return an error from there since there might be nothing
+	// to fetch if this is the first time the hypervisor is created.
+	if err := fc.storage.fetchHypervisorState(fc.id, &fc.info); err != nil {
+		fc.Logger().WithField("function", "init").WithError(err).Info("No info could be fetched")
+	}
 
 	return nil
 }
@@ -203,24 +216,24 @@ func (fc *firecracker) fcInit(timeout int) error {
 	args := []string{"--api-sock", fc.socketPath}
 
 	cmd := exec.Command(fc.config.HypervisorPath, args...)
-	err := cmd.Start()
-	if err != nil {
+	if err := cmd.Start(); err != nil {
 		fc.Logger().WithField("Error starting firecracker", err).Debug()
 		os.Exit(1)
 	}
 
+	fc.info.PID = cmd.Process.Pid
 	fc.firecrackerd = cmd
 	fc.client = fc.newFireClient()
 
-	err = fc.waitVMM(timeout)
-
-	if err != nil {
+	if err := fc.waitVMM(timeout); err != nil {
 		fc.Logger().WithField("fcInit failed:", err).Debug()
 		return err
 	}
 
 	fc.state.set(apiReady)
-	return nil
+
+	// Store VMM information
+	return fc.storage.storeHypervisorState(fc.id, fc.info)
 }
 
 func (fc *firecracker) fcSetBootSource(path, params string) error {
@@ -382,24 +395,52 @@ func (fc *firecracker) waitSandbox(timeout int) error {
 }
 
 // stopSandbox will stop the Sandbox's VM.
-func (fc *firecracker) stopSandbox() error {
+func (fc *firecracker) stopSandbox() (err error) {
 	span, _ := fc.trace("stopSandbox")
 	defer span.Finish()
 
-	fc.Logger().Info("Stopping Sandbox")
+	fc.Logger().Info("Stopping firecracker VM")
 
-	actionParams := ops.NewCreateSyncActionParams()
-	actionInfo := &models.InstanceActionInfo{
-		ActionType: "InstanceHalt",
+	defer func() {
+		if err != nil {
+			fc.Logger().Info("stopSandbox failed")
+		} else {
+			fc.Logger().Info("Firecracker VM stopped")
+		}
+	}()
+
+	pid := fc.info.PID
+
+	// Check if VM process is running, in case it is not, let's
+	// return from here.
+	if err = syscall.Kill(pid, syscall.Signal(0)); err != nil {
+		return nil
 	}
-	actionParams.SetInfo(actionInfo)
-	_, err := fc.client.Operations.CreateSyncAction(actionParams)
-	if err != nil {
-		fc.Logger().WithField("stopSandbox failed:", err).Debug()
+
+	// Send a SIGTERM to the VM process to try to stop it properly
+	if err = syscall.Kill(pid, syscall.SIGTERM); err != nil {
 		return err
 	}
 
-	return nil
+	// Wait for the VM process to terminate
+	tInit := time.Now()
+	for {
+		if err = syscall.Kill(pid, syscall.Signal(0)); err != nil {
+			return nil
+		}
+
+		if time.Since(tInit).Seconds() >= fcStopSandboxTimeout {
+			fc.Logger().Warnf("VM still running after waiting %ds", fcStopSandboxTimeout)
+			break
+		}
+
+		// Let's avoid to run a too busy loop
+		time.Sleep(time.Duration(50) * time.Millisecond)
+	}
+
+	// Let's try with a hammer now, a SIGKILL should get rid of the
+	// VM process.
+	return syscall.Kill(pid, syscall.SIGKILL)
 }
 
 func (fc *firecracker) pauseSandbox() error {


### PR DESCRIPTION
Because firecracker currently does not support a proper stop from
the caller, and because we don't want the agent to initiate a reboot
to shutdown the VM, the simplest and most efficient solution at the
moement is to signal the VM process with SIGTERM first, followed by
a SIGKILL if the process is still around.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>