### PR TITLE
kata_agent: Set the VmPath for each mmioblk device

### DIFF
--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -851,6 +851,7 @@ func (k *kataAgent) appendDevices(deviceList []*grpc.Device, c *Container) []*gr
 		if d.VirtPath != "" {
 			kataDevice.Type = kataMmioBlkDevType
 			kataDevice.Id = d.VirtPath
+			kataDevice.VmPath = d.VirtPath
 		} else if d.SCSIAddr == "" {
 			kataDevice.Type = kataBlkDevType
 			kataDevice.Id = d.PCIAddr


### PR DESCRIPTION
By not setting the VmPath for mmioblk devices, we prevent extra block
devices from being passed properly through the VM. In case of mmioblk,
there is no such thing as a PCI BDF, so we simply predict the name of
the device that will show up inside the VM.

By setting the VmPath field of the structure Device, we make sure the
agent receives the right information to find the device inside the VM.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>